### PR TITLE
Add support for ENV vars to control JVM memory allocation

### DIFF
--- a/bin/decaf
+++ b/bin/decaf
@@ -67,9 +67,12 @@ elif [ -d "/usr/local/decaf/java" ]; then
 fi
 
 # JVM Flags
-m='m'
-JVMFLAGS="-Xmx$FREEMEM$m"
-JVMFLAGS="$JVMFLAGS -Dfile.encoding=UTF-8"
+if [[ -z $JVM_MEMORY ]]; then
+  m='m'
+  JVM_MEMORY="-Xmx$FREEMEM$m"
+fi
+
+JVMFLAGS="$JVM_MEMORY -Dfile.encoding=UTF-8"
 
 if [ "$1" = "awt" ]; then
     shift


### PR DESCRIPTION
- Set memory via JVM_MEMORY environment variable using the JaVMFLAGS
  format for memory.
- Decaf will check for this env var, if absent, will use __half of available system memory__